### PR TITLE
5 return ip address after node creation

### DIFF
--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -31,8 +31,7 @@ def create_linode(module, client):
                 {'id': new_linode.id,
                  'ipv4': new_linode.ipv4,
                  'name': new_linode.label,
-                 'root_pass': root_pass,
-                 'dict': new_linode.__dict__}]}
+                 'root_pass': root_pass}]}
 
 
 def list_linodes(module, client):

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -29,8 +29,10 @@ def create_linode(module, client):
     return {'changed': True,
             'instances': [
                 {'id': new_linode.id,
+                 'ipv4': new_linode.ipv4,
                  'name': new_linode.label,
-                 'root_pass': root_pass}]}
+                 'root_pass': root_pass,
+                 'dict': new_linode.__dict__}]}
 
 
 def list_linodes(module, client):

--- a/test/units/modules/cloud/linode/conftest.py
+++ b/test/units/modules/cloud/linode/conftest.py
@@ -21,9 +21,14 @@ def linode_client():
     linode_api4.objects.Instance.delete = mock.MagicMock(
         linode_api4.objects.Instance, 'delete',
         autospec=True, return_value=True)
-    instance = linode_api4.objects.Instance.make_instance(
-        8675309, client)
+    # instance = linode_api4.objects.Instance.make_instance(
+    #    8675309, client)
+    instance = mock.MagicMock(
+        linode_api4.objects.Instance, 'make_instance',
+        autospec=True, return_value=linode_api4.objects.Instance)
     instance.label = 'eight.six.seven'
+    instance.id = 8675309
+    instance.ipv4 = '192.168.0.1'
     client.linode.instances = mock.Mock(
         client.linode.instances,
         return_value=PL.make_paginated_list(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```bash
ansible 2.8.0.dev0 (5-Return-IP-address-after-node-creation 87c81be406) last updated 2018/10/15 23:55:30 (GMT +000)
  config file = None
  configured module search path = ['/root/.ansible/content/*/*/modules', '/root/.ansible/plugins/modules', '/usr/share/ansible/content/*/*/modules', '/usr/share/ansible/plugins/modules']
  configured galaxy content search path = ['/root/.ansible/content']
  ansible python module location = /srv/ansible/lib/ansible
  executable location = /srv/ansible/bin/ansible
  python version = 3.7.0 (default, Sep 12 2018, 02:07:16) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
